### PR TITLE
Make Ollama URL and timeout configurable and improve UI

### DIFF
--- a/src/main/java/fr/baretto/ollamassist/ai/AutocompleteService.java
+++ b/src/main/java/fr/baretto/ollamassist/ai/AutocompleteService.java
@@ -35,8 +35,9 @@ public class AutocompleteService {
                 .temperature(0.2)
                 .topK(30)
                 .topP(0.7)
-                .baseUrl("http://localhost:11434")
+                .baseUrl(OllamAssistSettings.getInstance().getOllamaUrl())
                 .modelName(OllamAssistSettings.getInstance().getCompletionModelName())
+                .timeout(OllamAssistSettings.getInstance().getTimeoutDuration())
                 .build();
 
         return AiServices.builder(Service.class)

--- a/src/main/java/fr/baretto/ollamassist/chat/service/OllamaService.java
+++ b/src/main/java/fr/baretto/ollamassist/chat/service/OllamaService.java
@@ -62,13 +62,13 @@ public final class OllamaService implements Disposable, SettingsListener {
 
             ChatMemory chatMemory = MessageWindowChatMemory.withMaxMessages(15);
             messageBusConnection.subscribe(ConversationNotifier.TOPIC, (ConversationNotifier) chatMemory::clear);
-
             OllamaStreamingChatModel model = OllamaStreamingChatModel.builder()
                     .temperature(0.3)
                     .topK(40)
                     .topP(0.9)
-                    .baseUrl("http://localhost:11434")
+                    .baseUrl(OllamAssistSettings.getInstance().getOllamaUrl())
                     .modelName(OllamAssistSettings.getInstance().getChatModelName())
+                    .timeout(OllamAssistSettings.getInstance().getTimeoutDuration())
                     .build();
 
 

--- a/src/main/java/fr/baretto/ollamassist/chat/ui/AskToChatAction.java
+++ b/src/main/java/fr/baretto/ollamassist/chat/ui/AskToChatAction.java
@@ -1,17 +1,26 @@
 package fr.baretto.ollamassist.chat.ui;
 
+import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.TokenStream;
 import fr.baretto.ollamassist.chat.service.OllamaService;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 
 @Slf4j
 public class AskToChatAction implements ActionListener {
     private final PromptPanel promptPanel;
     private final MessagesPanel outputPanel;
     private final Context context;
+    private ChatThread currentChatThread;
 
     public AskToChatAction(PromptPanel promptInput, MessagesPanel outputPanel, Context context) {
         this.promptPanel = promptInput;
@@ -19,26 +28,88 @@ public class AskToChatAction implements ActionListener {
         this.context = context;
     }
 
-    private static void logException(Throwable throwable) {
+    private void logException(Throwable throwable) {
         log.error("Exception: " + throwable);
+        done(ChatResponse.builder().finishReason(FinishReason.OTHER).aiMessage(AiMessage.from(throwable.getMessage())).build());
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         String userMessage = promptPanel.getUserPrompt();
+        if (userMessage.isEmpty()) {
+            return;
+        }
+
+        if (currentChatThread != null) {
+            currentChatThread.stop();
+        }
+        outputPanel.cancelMessage();
         outputPanel.addUserMessage(userMessage);
         outputPanel.addNewAIMessage();
 
-        new Thread(() -> context.project()
-                .getService(OllamaService.class)
-                .getAssistant()
-                .chat(userMessage)
+        currentChatThread = ChatThread.builder()
+                .tokenStream(context.project()
+                        .getService(OllamaService.class)
+                        .getAssistant()
+                        .chat(userMessage))
                 .onNext(this::publish)
-                .onError(AskToChatAction::logException)
+                .onError(this::logException)
                 .onCompleteResponse(this::done)
-                .start()
-        ).start();
+                .build()
+                .start();
         promptPanel.clear();
+    }
+
+    @Builder
+    private static class ChatThread {
+
+        private final AtomicBoolean stopped = new AtomicBoolean(false);
+        private final Lock lock = new ReentrantLock();
+        private final TokenStream tokenStream;
+        private final Consumer<String> onNext;
+        private final Consumer<Throwable> onError;
+        private final Consumer<ChatResponse> onCompleteResponse;
+
+        public ChatThread start() {
+            new Thread(this::run).start();
+            return this;
+        }
+
+        private  void run() {
+            if (onNext != null) {
+                tokenStream.onNext(stoppable(onNext));
+            }
+            if (onError != null) {
+                tokenStream.onError(stoppable(onError));
+            }
+            if (onCompleteResponse != null) {
+                tokenStream.onCompleteResponse(stoppable(onCompleteResponse));
+            }
+            tokenStream.start();
+        }
+
+        public void stop() {
+            try {
+                lock.lock();
+                stopped.set(true);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private <T> Consumer<T> stoppable(java.util.function.Consumer<T> onNext) {
+            return (T t) -> {
+                try {
+                    lock.lock();
+                    if (!stopped.get()) {
+                        onNext.accept(t);
+                    }
+                } finally {
+                    lock.unlock();
+                }
+            };
+        }
+
     }
 
     private void done(ChatResponse chatResponse) {

--- a/src/main/java/fr/baretto/ollamassist/chat/ui/IconUtils.java
+++ b/src/main/java/fr/baretto/ollamassist/chat/ui/IconUtils.java
@@ -34,6 +34,8 @@ public class IconUtils {
     public static final Icon NEW_CONVERSATION = load("/icons/new_conversation.svg");
     public static final Icon INSERT = load("/icons/insert.svg");
     public static final Icon COPY = load("/icons/copy.svg");
+    public static final Icon OLLAMASSIST_WARN_ICON = AllIcons.General.Warning;
+    public static final Icon OLLAMASSIST_ERROR_ICON = AllIcons.General.Error;
     public static final Icon VALIDATE = load("/icons/checkmark.svg");
     public static final Icon ERROR = load("/icons/error.svg");
     public static final Icon INFORMATION = load("/icons/information.svg");

--- a/src/main/java/fr/baretto/ollamassist/chat/ui/SyntaxHighlighterPanel.java
+++ b/src/main/java/fr/baretto/ollamassist/chat/ui/SyntaxHighlighterPanel.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.util.ui.JBUI;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -23,6 +24,7 @@ public class SyntaxHighlighterPanel extends JPanel {
     private static final String INSERT = "Insert";
     private static final String COPY_TO_CLIPBOARD = "Copy to clipboard";
     private final RSyntaxTextArea codeBlock;
+    private final JScrollPane scrollPane;
     private final JPanel parentPanel;
     private final Context context;
     private final JLabel languageLabel = new JLabel();
@@ -39,6 +41,8 @@ public class SyntaxHighlighterPanel extends JPanel {
         codeBlock.setAutoIndentEnabled(true);
         codeBlock.setEditable(false);
         updateTheme();
+
+        scrollPane = new JBScrollPane(codeBlock, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED, JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
         JPanel headerPanel = new JPanel(new BorderLayout());
 
@@ -57,7 +61,7 @@ public class SyntaxHighlighterPanel extends JPanel {
         copyButton.addActionListener(e -> copyToClipboard());
 
         add(headerPanel, BorderLayout.NORTH);
-        add(codeBlock, BorderLayout.CENTER);
+        add(scrollPane, BorderLayout.CENTER);
     }
 
     private void copyToClipboard() {
@@ -96,13 +100,10 @@ public class SyntaxHighlighterPanel extends JPanel {
     }
 
     public void adjustSizeToContent() {
-        FontMetrics fontMetrics = codeBlock.getFontMetrics(codeBlock.getFont());
-        String[] lines = codeBlock.getText().split("\n");
-        int maxWidth = (int) (parentPanel.getWidth() * 0.9);
-        int lineHeight = fontMetrics.getHeight();
-        int preferredHeight = lineHeight * lines.length + 10;
+        codeBlock.setPreferredSize(null);
+        scrollPane.setMinimumSize(new Dimension(0, 0));
+        scrollPane.setPreferredSize(null);
 
-        codeBlock.setPreferredSize(new Dimension(maxWidth, preferredHeight));
         revalidate();
         repaint();
     }

--- a/src/main/java/fr/baretto/ollamassist/prerequiste/PrerequisiteService.java
+++ b/src/main/java/fr/baretto/ollamassist/prerequiste/PrerequisiteService.java
@@ -20,7 +20,6 @@ import java.util.function.Predicate;
 @NoArgsConstructor
 public class PrerequisiteService {
 
-    private static final String OLLAMA_HOST = "http://localhost:11434";
     public static final String PATH_TO_VERSION = "/api/version";
     public static final String PATH_TO_TAGS = "/api/tags";
 
@@ -39,7 +38,7 @@ public class PrerequisiteService {
     private CompletableFuture<Boolean> isOllamaAttributeExists(String endpoint, Predicate<String> check) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                String response = HttpRequests.request(OLLAMA_HOST + endpoint)
+                String response = HttpRequests.request(OllamAssistSettings.getInstance().getOllamaUrl() + endpoint)
                         .connectTimeout(3000)
                         .readTimeout(3000)
                         .readString();

--- a/src/main/java/fr/baretto/ollamassist/setting/ConfigurationPanel.java
+++ b/src/main/java/fr/baretto/ollamassist/setting/ConfigurationPanel.java
@@ -1,21 +1,32 @@
 package fr.baretto.ollamassist.setting;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.TextFieldWithAutoCompletion;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.components.fields.IntegerField;
 import com.intellij.util.ui.JBUI;
+import dev.langchain4j.model.ollama.OllamaModel;
+import dev.langchain4j.model.ollama.OllamaModels;
 import fr.baretto.ollamassist.events.StoreNotifier;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.util.Collections;
+import java.util.List;
+
+import static fr.baretto.ollamassist.setting.OllamAssistSettings.DEFAULT_URL;
 
 public class ConfigurationPanel extends JPanel {
 
-    private final JBTextField chatModel = new JBTextField();
-    private final JBTextField completionModel = new JBTextField();
+    private final JBTextField ollamaUrl = new JBTextField(DEFAULT_URL);
+    private final TextFieldWithAutoCompletion<String> chatModel;
+    private final TextFieldWithAutoCompletion<String> completionModel;
+    private final JBTextField timeout = new IntegerField(null, 0, Integer.MAX_VALUE);
     private final JBTextField sources = new JBTextField();
     private final Project project;
 
@@ -25,16 +36,33 @@ public class ConfigurationPanel extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBorder(JBUI.Borders.empty(10)); // Ajouter des marges globales
 
+        add(createLabeledField("Ollama URL:", ollamaUrl, "The URL of the Ollama server."));
+
+        chatModel = TextFieldWithAutoCompletion.create(project, Collections.emptyList(), true, null);
         add(createLabeledField("Chat model:", chatModel, "The model should be loaded before use."));
 
+        completionModel = TextFieldWithAutoCompletion.create(project, Collections.emptyList(), true, null);
         add(createLabeledField("Completion model:", completionModel, "The model should be loaded before use."));
+
+        add(createLabeledField("Response timeout:", timeout, "The total number of seconds allowed for a response."));
 
         add(createLabeledField("Indexed Folders:", sources, "Separated by ';'"));
 
         add(createClearEmbeddingButton());
+
+        ollamaUrl.addFocusListener(new java.awt.event.FocusAdapter() {
+            public void focusLost(java.awt.event.FocusEvent evt) {
+                new Thread(() -> updateAvailableModelsAutoCompletions()).start();
+            }
+
+            @Override
+            public void focusGained(FocusEvent e) {
+                ollamaUrl.setBackground(UIManager.getColor("TextField.background"));
+            }
+        });
     }
 
-    private JPanel createLabeledField(String label, JBTextField textField, String message) {
+    private JPanel createLabeledField(String label, JComponent textField, String message) {
         // Conteneur principal vertical pour le champ et le message
         JPanel panel = new JBPanel<>();
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS)); // Alignement vertical
@@ -47,9 +75,10 @@ public class ConfigurationPanel extends JPanel {
 
         panel.add(Box.createVerticalStrut(5)); // Espacement entre le label et le champ de texte
 
-        textField.setPreferredSize(new Dimension(200, 24));
-        textField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 24));
+        textField.setPreferredSize(new Dimension(200, 30));
+        textField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 30));
         textField.setAlignmentX(Component.LEFT_ALIGNMENT);
+        textField.setAlignmentY(Component.CENTER_ALIGNMENT);
         panel.add(textField);
 
         if (message != null) {
@@ -98,6 +127,15 @@ public class ConfigurationPanel extends JPanel {
         return panel;
     }
 
+    public String getOllamaUrl() {
+        return ollamaUrl.getText().trim();
+    }
+
+    public void setOllamaUrl(String url) {
+        ollamaUrl.setText(url.trim());
+        updateAvailableModelsAutoCompletions();
+    }
+
     public String getChatModel() {
         return chatModel.getText().trim();
     }
@@ -114,12 +152,41 @@ public class ConfigurationPanel extends JPanel {
         this.sources.setText(sources.trim());
     }
 
+    public String getTimeout() {
+        return timeout.getText().trim();
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout.setText(timeout.trim());
+    }
+
     public void setChatModelName(String chatModelName) {
         chatModel.setText(chatModelName.trim());
     }
 
     public void setCompletionModelName(String completionModelName) {
         completionModel.setText(completionModelName.trim());
+    }
+
+    private List<OllamaModel> fetchAvailableModels() {
+        return OllamaModels.builder()
+                .baseUrl(ollamaUrl.getText() == null ? DEFAULT_URL : ollamaUrl.getText())
+                .build().availableModels().content();
+    }
+
+    private void updateAvailableModelsAutoCompletions() {
+        try {
+            List<OllamaModel> availableModels = fetchAvailableModels();
+            chatModel.setVariants(availableModels.stream().map(OllamaModel::getName).toList());
+            completionModel.setVariants(availableModels.stream().map(OllamaModel::getName).toList());
+            ollamaUrl.setForeground(UIManager.getColor("TextField.foreground"));
+        } catch (RuntimeException e) {
+//            Messages.showErrorDialog("Could not connect to the Ollama server. Please check the URL.", "Connection Error");
+            chatModel.setVariants(Collections.emptyList());
+            completionModel.setVariants(Collections.emptyList());
+            ollamaUrl.setForeground(
+                    JBColor.RED);
+        }
     }
 
 }

--- a/src/main/java/fr/baretto/ollamassist/setting/OllamAssistSettings.java
+++ b/src/main/java/fr/baretto/ollamassist/setting/OllamAssistSettings.java
@@ -8,12 +8,15 @@ import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.time.Duration;
+
 @State(
         name = "OllamAssist",
         storages = {@Storage("OllamAssist.xml")}
 )
 public class OllamAssistSettings implements PersistentStateComponent<OllamAssistSettings.State> {
 
+    public static final String DEFAULT_URL = "http://localhost:11434";
     private State myState = new State();
 
     public static OllamAssistSettings getInstance() {
@@ -34,6 +37,14 @@ public class OllamAssistSettings implements PersistentStateComponent<OllamAssist
         myState = state;
     }
 
+    public String getOllamaUrl() {
+        return myState.ollamaUrl;
+    }
+
+    public void setOllamaUrl(String url) {
+        myState.ollamaUrl = url;
+    }
+
     public String getChatModelName() {
         return myState.chatModelName;
     }
@@ -50,6 +61,22 @@ public class OllamAssistSettings implements PersistentStateComponent<OllamAssist
         myState.completionModelName = modelName;
     }
 
+    public Duration getTimeoutDuration() {
+        try {
+            return Duration.ofSeconds(Long.parseLong(myState.timeout));
+        } catch (NumberFormatException e) {
+            return Duration.ofSeconds(300);
+        }
+    }
+
+    public String getTimeout() {
+        return myState.timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        myState.timeout = timeout;
+    }
+
     public String getSources() {
         return myState.sources;
     }
@@ -60,8 +87,10 @@ public class OllamAssistSettings implements PersistentStateComponent<OllamAssist
 
     @Getter
     public static class State {
+        public String ollamaUrl = DEFAULT_URL;
         public String chatModelName = "llama3.1";
         public String completionModelName = "llama3.1";
+        public String timeout = "300";
         public String sources = "src/";
     }
 

--- a/src/main/java/fr/baretto/ollamassist/setting/OllamassistSettingsConfigurable.java
+++ b/src/main/java/fr/baretto/ollamassist/setting/OllamassistSettingsConfigurable.java
@@ -26,8 +26,10 @@ public class OllamassistSettingsConfigurable implements Configurable, Disposable
     public JComponent createComponent() {
 
         OllamAssistSettings settings = OllamAssistSettings.getInstance();
+        configurationPanel.setOllamaUrl(settings.getOllamaUrl());
         configurationPanel.setChatModelName(settings.getChatModelName());
         configurationPanel.setCompletionModelName(settings.getCompletionModelName());
+        configurationPanel.setTimeout(settings.getTimeout());
         configurationPanel.setSources(settings.getSources());
         return configurationPanel;
     }
@@ -35,8 +37,10 @@ public class OllamassistSettingsConfigurable implements Configurable, Disposable
     @Override
     public boolean isModified() {
         OllamAssistSettings settings = OllamAssistSettings.getInstance();
-        return !configurationPanel.getChatModel().equalsIgnoreCase(settings.getChatModelName()) ||
+        return !configurationPanel.getOllamaUrl().equalsIgnoreCase(settings.getOllamaUrl()) ||
+                !configurationPanel.getChatModel().equalsIgnoreCase(settings.getChatModelName()) ||
                 !configurationPanel.getCompletionModel().equalsIgnoreCase(settings.getCompletionModelName()) ||
+                !configurationPanel.getTimeout().equalsIgnoreCase(settings.getTimeout()) ||
                 !configurationPanel.getSources().equalsIgnoreCase(settings.getSources());
     }
 
@@ -48,8 +52,10 @@ public class OllamassistSettingsConfigurable implements Configurable, Disposable
 
         if (modified) {
 
+            settings.setOllamaUrl(configurationPanel.getOllamaUrl());
             settings.setChatModelName(configurationPanel.getChatModel());
             settings.setCompletionModelName(configurationPanel.getCompletionModel());
+            settings.setTimeout(configurationPanel.getTimeout());
             settings.setSources(configurationPanel.getSources());
 
 
@@ -62,8 +68,10 @@ public class OllamassistSettingsConfigurable implements Configurable, Disposable
     @Override
     public void reset() {
         OllamAssistSettings settings = OllamAssistSettings.getInstance();
+        configurationPanel.setOllamaUrl(settings.getOllamaUrl().trim());
         configurationPanel.setChatModelName(settings.getChatModelName().trim());
         configurationPanel.setCompletionModelName(settings.getCompletionModelName().trim());
+        configurationPanel.setTimeout(settings.getTimeout().trim());
         configurationPanel.setSources(settings.getSources().trim());
     }
 


### PR DESCRIPTION
- make Ollama url and timeout configurable
- fetch available models and autocomplete in configuration dialog
- suppress displaying more tokens from a canceled request (suboptimal solution, since tokens will still be generated in the background)
- distinguish completed, canceled and erroneous (e.g. timed-out) requests with different icons and add informational tooltips
- add horizontal scrollbar (when necessary) to code output (SyntaxHighlighterPanel)
- fix vertical alignment of responses