### PR TITLE
feat: configure for all jetbrains product

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ version = "1.0.4"
 
 repositories {
     mavenCentral()
-    gradlePluginPortal()
 }
 
 dependencies {
@@ -49,7 +48,7 @@ dependencies {
 intellij {
     version.set("2024.3")
     type.set("IC")
-    plugins.set(listOf("java"))
+    plugins.set(listOf())
 }
 
 tasks {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -89,7 +89,6 @@
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
-    <depends>com.intellij.modules.java</depends>
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Configure OllamAssist for all jetbrains products: I just test with WebStorm, I think It will be ok for all products:

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/ddd471f6-fc9d-4d45-af1a-1c54a505b143" />
