### PR TITLE
Remove dependencies that conflict with 2025.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ repositories {
 }
 val langchain4jEasyRag = "1.4.0-beta10"
 val langchain4jVersion = "1.4.0"
-val apacheLuceneVersion = "9.12.1"
 val mockitoVersion = "5.19.0"
 val lombokVersion = "1.18.38"
 val junitJupiterVersion = "5.11.0-M2"
@@ -59,15 +58,30 @@ dependencies {
     implementation("ai.djl.huggingface:tokenizers:$djlVersion")
 
 
-    implementation("dev.langchain4j:langchain4j-ollama:$langchain4jVersion")
-    implementation("dev.langchain4j:langchain4j-core:$langchain4jVersion")
-    implementation("dev.langchain4j:langchain4j:$langchain4jVersion")
+    implementation("dev.langchain4j:langchain4j-ollama:$langchain4jVersion"){
+        exclude(group = "org.apache.lucene")
+        exclude(group = "org.slf4j")
+    }
+    implementation("dev.langchain4j:langchain4j-core:$langchain4jVersion"){
+        exclude(group = "org.apache.lucene")
+        exclude(group = "org.slf4j")
+    }
+    implementation("dev.langchain4j:langchain4j:$langchain4jVersion"){
+        exclude(group = "org.apache.lucene")
+        exclude(group = "org.slf4j")
+    }
     implementation("dev.langchain4j:langchain4j-easy-rag:$langchain4jEasyRag") {
         exclude(group = "xml-apis")
         exclude(group = "ai.djl", module = "api")
         exclude(group = "ai.djl.huggingface", module = "tokenizers")
+        exclude(group = "org.apache.lucene")
+        exclude(group = "org.slf4j")
     }
-    implementation("dev.langchain4j:langchain4j-reactor:$langchain4jEasyRag")
+    implementation("dev.langchain4j:langchain4j-reactor:$langchain4jEasyRag") {
+        exclude(group = "org.apache.lucene")
+        exclude(group = "org.slf4j")
+    }
+    runtimeOnly("org.slf4j:slf4j-jdk14:1.7.36")
     implementation("org.codehaus.plexus:plexus-utils:$plexusVersion")
     implementation("org.jsoup:jsoup:$jsoupVersion")
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
@@ -75,12 +89,6 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
 
 
-    implementation("org.apache.lucene:lucene-core:$apacheLuceneVersion")
-    implementation("org.apache.lucene:lucene-analysis-common:$apacheLuceneVersion")
-    implementation("org.apache.lucene:lucene-codecs:$apacheLuceneVersion")
-    implementation("org.apache.lucene:lucene-highlighter:$apacheLuceneVersion")
-    implementation("org.apache.lucene:lucene-queryparser:$apacheLuceneVersion")
-    implementation("org.apache.lucene:lucene-memory:$apacheLuceneVersion")
 
     implementation("com.fifesoft:rsyntaxtextarea:$rsyntaxtextareaVersion")
 


### PR DESCRIPTION
Hi there, 

Really appreciate your work here. I tried the plugin out in the 2025.3 EAP, and it wouldn't start. 

<summary>On investigation, it seemed to be due to this error:
<details>



```plaintext
2025-10-17 12:45:15,599 [   8080] SEVERE - #c.i.o.p.Task - org.apache.lucene.codecs.Codec: org.apache.lucene.codecs.lucene103.Lucene103Codec not a subtype [Plugin: fr.baretto.OllamAssist]
com.intellij.diagnostic.PluginException: org.apache.lucene.codecs.Codec: org.apache.lucene.codecs.lucene103.Lucene103Codec not a subtype [Plugin: fr.baretto.OllamAssist]
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance$suspendImpl(ServiceInstanceInitializer.kt:52)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance(ServiceInstanceInitializer.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invokeSuspend(LazyInstanceHolder.kt:165)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:166)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invokeSuspend(LazyInstanceHolder.kt:163)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.initialize(LazyInstanceHolder.kt:148)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.access$initialize(LazyInstanceHolder.kt:15)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.tryInitialize(LazyInstanceHolder.kt:138)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstance(LazyInstanceHolder.kt:96)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext$suspendImpl(LazyInstanceHolder.kt:88)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext(LazyInstanceHolder.kt)
	at com.intellij.serviceContainer.ComponentManagerImplKt$doGetOrCreateInstanceBlocking$1.invokeSuspend(ComponentManagerImpl.kt:1561)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:112)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlockingWithParallelismCompensation(Builders.kt:61)
	at kotlinx.coroutines.BuildersKt.runBlockingWithParallelismCompensation(Unknown Source)
	at kotlinx.coroutines.internal.intellij.IntellijCoroutines.runBlockingWithParallelismCompensation(intellij.kt:48)
	at com.intellij.util.IntelliJCoroutinesFacade.runBlockingWithParallelismCompensation(IntelliJCoroutinesFacade.kt:35)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization$lambda$0(ComponentManagerImpl.kt:1692)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext$lambda$0(context.kt:83)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext(context.kt:82)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization(ComponentManagerImpl.kt:1677)
	at com.intellij.serviceContainer.ComponentManagerImplKt.doGetOrCreateInstanceBlocking(ComponentManagerImpl.kt:1560)
	at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1549)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:715)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:653)
	at fr.baretto.ollamassist.chat.rag.DocumentIndexingPipeline.<init>(DocumentIndexingPipeline.java:39)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$0(instantiate.kt:46)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$3$0(instantiate.kt:288)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.withStoredTemporaryContext(instantiate.kt:304)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:287)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:39)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance$suspendImpl(ServiceInstanceInitializer.kt:29)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance(ServiceInstanceInitializer.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invokeSuspend(LazyInstanceHolder.kt:165)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:166)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invokeSuspend(LazyInstanceHolder.kt:163)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.initialize(LazyInstanceHolder.kt:148)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.access$initialize(LazyInstanceHolder.kt:15)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.tryInitialize(LazyInstanceHolder.kt:138)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstance(LazyInstanceHolder.kt:96)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext$suspendImpl(LazyInstanceHolder.kt:88)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext(LazyInstanceHolder.kt)
	at com.intellij.serviceContainer.ComponentManagerImplKt$doGetOrCreateInstanceBlocking$1.invokeSuspend(ComponentManagerImpl.kt:1561)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:112)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlockingWithParallelismCompensation(Builders.kt:61)
	at kotlinx.coroutines.BuildersKt.runBlockingWithParallelismCompensation(Unknown Source)
	at kotlinx.coroutines.internal.intellij.IntellijCoroutines.runBlockingWithParallelismCompensation(intellij.kt:48)
	at com.intellij.util.IntelliJCoroutinesFacade.runBlockingWithParallelismCompensation(IntelliJCoroutinesFacade.kt:35)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization$lambda$0(ComponentManagerImpl.kt:1692)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext$lambda$0(context.kt:83)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext(context.kt:82)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization(ComponentManagerImpl.kt:1677)
	at com.intellij.serviceContainer.ComponentManagerImplKt.doGetOrCreateInstanceBlocking(ComponentManagerImpl.kt:1560)
	at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1549)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:715)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:653)
	at fr.baretto.ollamassist.chat.service.OllamaService.<init>(OllamaService.java:43)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$0(instantiate.kt:46)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$3$0(instantiate.kt:288)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.withStoredTemporaryContext(instantiate.kt:304)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:287)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:39)
	at com.intellij.serviceContainer.LightServiceInstanceSupport$LightServiceInstanceInitializer.createInstance(LightServiceInstanceSupport.kt:43)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invokeSuspend(LazyInstanceHolder.kt:165)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:44)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:166)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invokeSuspend(LazyInstanceHolder.kt:163)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder$initialize$1.invoke(LazyInstanceHolder.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startCoroutineUndispatched(Undispatched.kt:20)
	at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:360)
	at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:134)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
	at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.initialize(LazyInstanceHolder.kt:148)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.access$initialize(LazyInstanceHolder.kt:15)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.tryInitialize(LazyInstanceHolder.kt:138)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstance(LazyInstanceHolder.kt:96)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext$suspendImpl(LazyInstanceHolder.kt:88)
	at com.intellij.platform.instanceContainer.internal.LazyInstanceHolder.getInstanceInCallerContext(LazyInstanceHolder.kt)
	at com.intellij.serviceContainer.ComponentManagerImplKt$doGetOrCreateInstanceBlocking$1.invokeSuspend(ComponentManagerImpl.kt:1561)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:112)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$BuildersKt__BuildersKt(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlockingWithParallelismCompensation(Builders.kt:61)
	at kotlinx.coroutines.BuildersKt.runBlockingWithParallelismCompensation(Unknown Source)
	at kotlinx.coroutines.internal.intellij.IntellijCoroutines.runBlockingWithParallelismCompensation(intellij.kt:48)
	at com.intellij.util.IntelliJCoroutinesFacade.runBlockingWithParallelismCompensation(IntelliJCoroutinesFacade.kt:35)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization$lambda$0(ComponentManagerImpl.kt:1692)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext$lambda$0(context.kt:83)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.progress.ContextKt.prepareThreadContext(context.kt:82)
	at com.intellij.serviceContainer.ComponentManagerImplKt.runBlockingInitialization(ComponentManagerImpl.kt:1677)
	at com.intellij.serviceContainer.ComponentManagerImplKt.doGetOrCreateInstanceBlocking(ComponentManagerImpl.kt:1560)
	at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1549)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:715)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:653)
	at fr.baretto.ollamassist.prerequiste.PrerequisitesPanel.lambda$checkPrerequisitesAsync$3(PrerequisitesPanel.java:259)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:718)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1773)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:167)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:173)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:167)
	at com.intellij.util.concurrency.ContextRunnable.lambda$run$0(ContextRunnable.java:26)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:25)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.ServiceConfigurationError: org.apache.lucene.codecs.Codec: org.apache.lucene.codecs.lucene103.Lucene103Codec not a subtype
	at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
	at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
	at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
	at org.apache.lucene.util.NamedSPILoader.reload(NamedSPILoader.java:68)
	at org.apache.lucene.util.NamedSPILoader.<init>(NamedSPILoader.java:52)
	at org.apache.lucene.util.NamedSPILoader.<init>(NamedSPILoader.java:38)
	at org.apache.lucene.codecs.Codec$Holder.<clinit>(Codec.java:45)
	at org.apache.lucene.codecs.Codec.getDefault(Codec.java:141)
	at org.apache.lucene.index.LiveIndexWriterConfig.<init>(LiveIndexWriterConfig.java:131)
	at org.apache.lucene.index.IndexWriterConfig.<init>(IndexWriterConfig.java:145)
	at fr.baretto.ollamassist.chat.rag.LuceneEmbeddingStore.initIndexWriter(LuceneEmbeddingStore.java:71)
	at fr.baretto.ollamassist.chat.rag.LuceneEmbeddingStore.retrieveIndexWriter(LuceneEmbeddingStore.java:79)
	at fr.baretto.ollamassist.chat.rag.LuceneEmbeddingStore.<init>(LuceneEmbeddingStore.java:66)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$0(instantiate.kt:46)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate$lambda$3$0(instantiate.kt:288)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.withStoredTemporaryContext(instantiate.kt:304)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:287)
	at com.intellij.platform.instanceContainer.instantiation.InstantiateKt.instantiate(instantiate.kt:39)
	at com.intellij.serviceContainer.ServiceInstanceInitializer.createInstance$suspendImpl(ServiceInstanceInitializer.kt:29)
	... 153 more
2025-10-17 12:45:15,602 [   8083] SEVERE - #c.i.o.p.Task - IntelliJ IDEA 2025.3 EAP  Build #IU-253.25908.13
2025-10-17 12:45:15,602 [   8083] SEVERE - #c.i.o.p.Task - JDK: 21.0.8; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o.
2025-10-17 12:45:15,602 [   8083] SEVERE - #c.i.o.p.Task - OS: Windows 11
2025-10-17 12:45:15,602 [   8083] SEVERE - #c.i.o.p.Task - Plugin to blame: OllamAssist version: 1.7.1
2025-10-17 12:45:15,602 [   8083] SEVERE - #c.i.o.p.Task - Last Action: 
```
</details></summary>
I guess the IDE's lucene library has been upgraded in 2025.3 and explicitly defining it in OllamAssist causes a conflict.

Removing it entirely from the dependencies appears to fix the issue. 

There was also a similar issue with `dev.langchain4j`, which was resolved by excluding lucene from those dependencies. 

I also implemented the recommendations here:https://blog.jetbrains.com/platform/2022/02/removing-log4j-from-the-intellij-platform/ and added a runtime dependency on `org.slf4j:slf4j-jdk14:1.7.36` to get the logs working again.  

I hope all this was useful to you. Keep up the good work!


